### PR TITLE
Adjust view multipliers for smaller creator tiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,9 +484,9 @@
       Icon: { rate: 1.636, views: 2.083 },
       Mega: { rate: 1.273, views: 1.458 },
       Macro: { rate: 1, views: 1 },
-      HMid: { rate: 0.818, views: 0.5 },
-      LMid: { rate: 0.636, views: 0.333 },
-      Micro: { rate: 0.5, views: 0.188 },
+      HMid: { rate: 0.818, views: 0.45 },
+      LMid: { rate: 0.636, views: 0.22 },
+      Micro: { rate: 0.5, views: 0.07 },
     };
 
     const SIZE_FOLLOWERS = {


### PR DESCRIPTION
## Summary
- reduce the high-mid, lower-mid, and micro creator view multipliers so organic view forecasts better match typical follower volumes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae94d783c83308d10906a6e2f1808