### PR TITLE
Rename ad rate metric to organic CPV

### DIFF
--- a/index.html
+++ b/index.html
@@ -1328,7 +1328,7 @@
       const pricePerCreator = totalCreators > 0 ? totalPrice / totalCreators : 0;
       const totalViews = organicViewsAdjusted + paidViews;
       const brandCPM = totalViews > 0 ? (totalPrice / totalViews) * 1000 : 0;
-      const adRateCpv = organicViewsAdjusted > 0 ? gatingAdjustedContent / organicViewsAdjusted : 0;
+      const organicCpv = organicViewsAdjusted > 0 ? gatingAdjustedContent / organicViewsAdjusted : 0;
 
       updateSummary({
         contentSubtotal,
@@ -1350,7 +1350,7 @@
         totalViews,
         platformViews,
         totalEstimatedFollowers,
-        adRateCpv,
+        organicCpv,
         approvalsNeeded: gating.approvalsNeeded,
       });
 
@@ -1392,7 +1392,7 @@
         ['Total Price', formatCurrency(data.totalPrice)],
         ['Price / Creator', formatCurrency(data.pricePerCreator)],
         ['Gross Margin', formatCurrency(data.grossMargin)],
-        ['Ad Rate (CPV)', formatCpv(data.adRateCpv)],
+        ['Organic CPV', formatCpv(data.organicCpv)],
         ['Brand CPM', isFinite(data.brandCPM) ? `$${data.brandCPM.toFixed(2)}` : '$0.00'],
       ];
       items.forEach(([label, value]) => {


### PR DESCRIPTION
## Summary
- rename the ad rate metric to "Organic CPV" throughout the summary calculation
- keep the CPV formula aligned with the existing organic cost and view values

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68dae397cee48330995562b489aac003