### PR TITLE
Add Cogs CPV column and update CPV calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,8 @@
                 <th>No. Creators</th>
                 <th>No. Content Each</th>
                 <th>Views per Piece</th>
-                <th>CPV ($)</th>
+                <th>Cogs CPV ($)</th>
+                <th>Client CPV ($)</th>
                 <th>Total COGs</th>
                 <th></th>
               </tr>
@@ -555,7 +556,7 @@
             <input type="number" id="paid-budget" min="0" step="100" />
           </div>
           <div class="input-row">
-            <label id="paid-rate-label" for="paid-rate">CPV</label>
+            <label id="paid-rate-label" for="paid-rate">Client CPV</label>
             <input type="number" id="paid-rate" min="0" step="0.001" />
           </div>
         </div>
@@ -653,7 +654,7 @@
       viewMix: createChartState('view-mix-chart'),
     };
 
-    const CPV_WITH_MARGIN_LABEL = 'CPV';
+    const CPV_WITH_MARGIN_LABEL = 'Client CPV';
 
     const DEFAULT_PAID_RATES = {
       cpv: 0.03,
@@ -1365,15 +1366,27 @@
         viewsTd.appendChild(viewsDisplay);
         tr.appendChild(viewsTd);
 
-        const unitRateTd = document.createElement('td');
-        const unitRateDisplay = document.createElement('div');
-        unitRateDisplay.className = 'readonly-value';
-        unitRateDisplay.textContent = formatCpv(line.unitRate || 0);
-        unitRateTd.appendChild(unitRateDisplay);
-        tr.appendChild(unitRateTd);
+        const currentLineTotal = calculateLineTotal(line);
+
+        const cogsCpvTd = document.createElement('td');
+        const cogsCpvDisplay = document.createElement('div');
+        cogsCpvDisplay.className = 'readonly-value cogs-cpv';
+        const initialCogsCpv = Number.isFinite(line.cpvWithWhitelist)
+          ? line.cpvWithWhitelist
+          : line.unitRate || 0;
+        cogsCpvDisplay.textContent = formatCpv(initialCogsCpv);
+        cogsCpvTd.appendChild(cogsCpvDisplay);
+        tr.appendChild(cogsCpvTd);
+
+        const clientCpvTd = document.createElement('td');
+        const clientCpvDisplay = document.createElement('div');
+        clientCpvDisplay.className = 'readonly-value client-cpv';
+        clientCpvDisplay.textContent = formatCpv(initialCogsCpv);
+        clientCpvTd.appendChild(clientCpvDisplay);
+        tr.appendChild(clientCpvTd);
 
         const lineTotalTd = document.createElement('td');
-        lineTotalTd.textContent = formatCurrency(calculateLineTotal(line));
+        lineTotalTd.textContent = formatCurrency(currentLineTotal);
         tr.appendChild(lineTotalTd);
 
         const deleteTd = document.createElement('td');
@@ -1655,7 +1668,9 @@
       const priceMultiplier = totalCOGs > 0 ? totalPrice / totalCOGs : 1;
       contentLines.forEach(line => {
         const baseCpv = Number.isFinite(line.cpvWithWhitelist) ? line.cpvWithWhitelist : line.unitRate || 0;
-        const effectiveCpv = baseCpv * (modifiers.feeMultiplier ?? 1) * priceMultiplier;
+        const cogsCpv = baseCpv * (modifiers.feeMultiplier ?? 1);
+        line.cogsCpv = Number.isFinite(cogsCpv) ? cogsCpv : 0;
+        const effectiveCpv = line.cogsCpv * priceMultiplier;
         line.effectiveCpv = Number.isFinite(effectiveCpv) ? effectiveCpv : 0;
       });
       const influencerClientCost = feeAdjustedContent * priceMultiplier;
@@ -2008,15 +2023,27 @@
         if (viewDisplay) {
           viewDisplay.textContent = formatNumber(line.viewsPerPiece || 0);
         }
-        const cpvCell = row.children?.[9];
-        const cpvDisplay = cpvCell?.querySelector('.readonly-value');
-        if (cpvDisplay) {
+        const cogsCpvDisplay = row.querySelector('.cogs-cpv');
+        if (cogsCpvDisplay) {
+          const cogsValue = Number.isFinite(line.cogsCpv)
+            ? line.cogsCpv
+            : Number.isFinite(line.cpvWithWhitelist)
+              ? line.cpvWithWhitelist
+              : line.unitRate || 0;
+          cogsCpvDisplay.textContent = formatCpv(cogsValue);
+        }
+        const clientCpvDisplay = row.querySelector('.client-cpv');
+        if (clientCpvDisplay) {
           const cpvValue = Number.isFinite(line.effectiveCpv)
             ? line.effectiveCpv
-            : line.unitRate || 0;
-          cpvDisplay.textContent = formatCpv(cpvValue);
+            : Number.isFinite(line.cogsCpv)
+              ? line.cogsCpv
+              : Number.isFinite(line.cpvWithWhitelist)
+                ? line.cpvWithWhitelist
+                : line.unitRate || 0;
+          clientCpvDisplay.textContent = formatCpv(cpvValue);
         }
-        const totalCell = row.children?.[10];
+        const totalCell = row.children?.[11];
         if (totalCell) {
           totalCell.textContent = formatCurrency(line.total);
         }


### PR DESCRIPTION
## Summary
- add a dedicated Cogs CPV column to the build table and rename the existing CPV column to Client CPV
- derive Cogs CPV from the whitelist-adjusted rate without margin and keep Client CPV tied to the selling rate
- update CPV labels and realtime row refresh logic to surface the new calculations consistently

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc0f35f2188330a792112c3246bbdf