### PR TITLE
Limit chart grid to four columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,25 @@
     .chart-grid {
       display: grid;
       gap: 0.75rem;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    @media (min-width: 640px) {
+      .chart-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 960px) {
+      .chart-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1280px) {
+      .chart-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
     }
 
     .chart-card {


### PR DESCRIPTION
## Summary
- adjust the chart grid styling so no more than four charts appear per row across breakpoints

## Testing
- no tests were run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dce9a107e483309c5038654a34860c