### PR TITLE
Add CSV export and pricing variables menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,188 @@
       box-shadow: 0 12px 18px -12px rgba(248, 113, 113, 0.65);
     }
 
+    .pricing-menu-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.8);
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      overflow-y: auto;
+      padding: 2.5rem 1.5rem;
+      z-index: 2000;
+    }
+
+    .pricing-menu {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      width: min(960px, 100%);
+      max-height: calc(100vh - 3rem);
+      overflow-y: auto;
+      padding: 1.5rem;
+      box-shadow: 0 32px 64px -40px rgba(8, 15, 32, 0.9);
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .pricing-menu-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1rem;
+    }
+
+    .pricing-menu-header h3 {
+      margin: 0;
+      font-size: 1.1rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #cbd5f5;
+    }
+
+    .pricing-menu-description {
+      margin: 0.35rem 0 0;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .pricing-menu-close {
+      background: rgba(148, 163, 184, 0.15);
+      color: #cbd5f5;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    .pricing-menu-toggle {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .pricing-menu-toggle label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8rem;
+      color: var(--muted);
+      cursor: pointer;
+    }
+
+    .pricing-menu-section {
+      border: 1px solid rgba(148, 163, 184, 0.14);
+      border-radius: 14px;
+      padding: 1rem;
+      background: rgba(15, 23, 42, 0.4);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .pricing-menu-section h4 {
+      margin: 0;
+      font-size: 0.9rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #cbd5f5;
+    }
+
+    .pricing-menu-section p {
+      margin: 0;
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+
+    .pricing-variable-grid {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .pricing-variable-item {
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      border-radius: 12px;
+      padding: 0.75rem;
+      background: rgba(15, 23, 42, 0.55);
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .pricing-variable-label {
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .pricing-variable-value {
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    .pricing-menu-table-wrapper {
+      overflow-x: auto;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(15, 23, 42, 0.5);
+    }
+
+    .pricing-menu-table-wrapper table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8rem;
+    }
+
+    .pricing-menu-table-wrapper th,
+    .pricing-menu-table-wrapper td {
+      padding: 0.5rem 0.65rem;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+      text-align: left;
+    }
+
+    .pricing-menu-table-wrapper th {
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .pricing-menu-table-wrapper tr:last-child td {
+      border-bottom: none;
+    }
+
+    .pricing-deliverable-grid {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .pricing-deliverable-card {
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      border-radius: 12px;
+      padding: 0.75rem;
+      background: rgba(15, 23, 42, 0.55);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .pricing-deliverable-card h5 {
+      margin: 0;
+      font-size: 0.85rem;
+      color: #cbd5f5;
+    }
+
+    .pricing-deliverable-meta {
+      font-size: 0.75rem;
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+    }
+
+    .pricing-deliverable-meta strong {
+      color: #e2e8f0;
+    }
+
     aside {
       position: sticky;
       top: 1.5rem;
@@ -1393,6 +1575,55 @@
       marginGoal: 0,
     };
 
+    const pricingVariables = (() => {
+      const deliverables = {};
+      Object.entries(RATE_CARD).forEach(([platform, platformData]) => {
+        const platformDeliverables = {};
+        Object.entries(platformData.deliverables || {}).forEach(([deliverable, details]) => {
+          const baseViews = Number(details.baseViews || 0);
+          const cpv = Number(details.cpv || 0);
+          const cpvByVertical = { ...(details.cpvByVertical || {}) };
+          const viewsBySize = details.viewsBySize
+            ? { ...details.viewsBySize }
+            : Object.fromEntries(
+                Object.keys(SIZE_MULT).map(size => {
+                  const sizeMultiplier = SIZE_MULT[size]?.views ?? 1;
+                  return [size, Math.round(baseViews * sizeMultiplier)];
+                }),
+              );
+          platformDeliverables[deliverable] = {
+            baseViews,
+            cpv,
+            cpvByVertical,
+            viewsBySize,
+          };
+        });
+        deliverables[platform] = platformDeliverables;
+      });
+
+      return Object.freeze({
+        general: {
+          marginGoal: defaultState.marginGoal,
+          rushFeeMultiplier: 1.15,
+          travelFeeMultiplier: 1.2,
+          nicheCreatorMultiplier: 1.2,
+          q4FeeMultiplier: 1.15,
+        },
+        paidMedia: {
+          defaultRates: { ...DEFAULT_PAID_RATES },
+        },
+        multipliers: {
+          size: structuredClone(SIZE_MULT),
+          vertical: structuredClone(VERTICAL_MULT),
+          language: structuredClone(LANGUAGE_MULT),
+          whitelist: structuredClone(WHITELIST_UPLIFT_PCT),
+          brandExcitement: BRAND_EXCITEMENT.map(entry => ({ ...entry })),
+        },
+        followers: structuredClone(SIZE_FOLLOWERS),
+        deliverables,
+      });
+    })();
+
     let state = loadState();
 
     // Merge raw persisted data with calculator defaults to keep structures stable.
@@ -1555,6 +1786,273 @@
         summary,
         data,
       };
+    }
+
+    function exportCampaignToCSV(campaign) {
+      if (!campaign) {
+        console.warn('No campaign selected to export.');
+        return;
+      }
+      try {
+        const source = campaign.data ? structuredClone(campaign.data) : structuredClone(campaign);
+        const normalized = normalizeCampaignState(source);
+        const summary = calculateCampaignSummaryFromData(normalized);
+        const modifiers = calculateModifiers(normalized);
+        const rawLines = Array.isArray(normalized.campaignLines) ? normalized.campaignLines : [];
+        const processedLines = rawLines.map(line => {
+          const working = structuredClone(line);
+          const baseTotal = calculateLineTotal(working) || 0;
+          const creators = Number(working.creators || 0);
+          const qtyPerCreator = Number(working.qtyPerCreator || 0);
+          const contentPieces = creators * qtyPerCreator;
+          const estimatedViews = (working.viewsPerPiece || 0)
+            * contentPieces
+            * (modifiers.organicViewMultiplier ?? 1);
+          const cogsTotal = baseTotal * (modifiers.feeMultiplier ?? 1);
+          const baseCpv = Number.isFinite(working.cpvWithWhitelist)
+            ? Number(working.cpvWithWhitelist)
+            : Number(working.unitRate || 0);
+          return {
+            platform: working.platform || 'Unknown',
+            deliverable: working.deliverable || 'Deliverable',
+            vertical: working.vertical || 'Unspecified',
+            language: working.language || 'Unspecified',
+            size: working.size || 'Unspecified',
+            creators,
+            qtyPerCreator,
+            contentPieces,
+            estimatedViews,
+            baseTotal,
+            cogsTotal,
+            baseCpv,
+          };
+        });
+
+        const feeAdjustedContent = processedLines.reduce((acc, line) => acc + (line.cogsTotal || 0), 0);
+        const otherTotal = (normalized.otherCosts?.other || 0)
+          + (normalized.otherCosts?.study || 0)
+          + (normalized.otherCosts?.additional || 0);
+        const travelCost = modifiers.travelRequired
+          ? (normalized.travel?.creators || 0) * (normalized.travel?.perCreator || 0)
+          : 0;
+        const paidBudget = Number(normalized.paidMedia?.budget || 0);
+        const baseCOGs = feeAdjustedContent + otherTotal + travelCost;
+        const totalCOGs = baseCOGs + paidBudget;
+        const marginGoalPct = Math.max(0, Number(normalized.marginGoal || 0)) / 100;
+        const markupMultiplier = marginGoalPct >= 1 ? 1 : 1 / (1 - marginGoalPct);
+        const totalPriceExcludingPaid = baseCOGs * markupMultiplier;
+        const priceMultiplier = baseCOGs > 0 ? totalPriceExcludingPaid / baseCOGs : 1;
+        const totalPrice = totalPriceExcludingPaid + paidBudget;
+        const paidViews = calculatePaidViews(normalized.paidMedia);
+
+        const detailedLines = processedLines.map(line => {
+          const clientTotal = line.cogsTotal * priceMultiplier;
+          const cogsCpv = line.estimatedViews > 0 ? line.cogsTotal / line.estimatedViews : 0;
+          const clientCpv = line.estimatedViews > 0 ? clientTotal / line.estimatedViews : 0;
+          const clientCpm = clientCpv * 1000;
+          return {
+            ...line,
+            clientTotal,
+            cogsCpv,
+            clientCpv,
+            clientCpm,
+          };
+        });
+
+        const campaignName = (campaign.name || normalized.details?.campaignName || 'Campaign').trim() || 'Campaign';
+        const brand = (normalized.details?.brand || '').trim();
+        const rush = normalized.details?.rush ? 'Yes' : 'No';
+        const travel = normalized.details?.travelNeeded ? 'Yes' : 'No';
+        const niche = normalized.details?.nicheCreators ? 'Yes' : 'No';
+        const marginGoalLabel = Number.isFinite(normalized.marginGoal)
+          ? Number(normalized.marginGoal).toFixed(2)
+          : '0.00';
+
+        const headers = [
+          'Campaign Name',
+          'Brand',
+          'Platform',
+          'Deliverable',
+          'Vertical',
+          'Language',
+          'Creator Size',
+          'Creators',
+          'Content Pieces',
+          'Estimated Views',
+          'Total COGS',
+          'Client Total',
+          'COGS CPV',
+          'Client CPV',
+          'Client CPM',
+          'Rush',
+          'Travel',
+          'Niche',
+          'Margin Goal (%)',
+        ];
+
+        function formatNumberValue(value, decimals) {
+          if (!Number.isFinite(value)) return '';
+          if (typeof decimals === 'number') {
+            return value.toFixed(decimals);
+          }
+          return String(value);
+        }
+
+        function wrapCsvValue(value) {
+          const stringValue = value == null ? '' : String(value);
+          if (/[",\n]/.test(stringValue)) {
+            return `"${stringValue.replace(/"/g, '""')}"`;
+          }
+          return stringValue;
+        }
+
+        const rows = [];
+
+        detailedLines.forEach(line => {
+          rows.push([
+            campaignName,
+            brand,
+            line.platform,
+            line.deliverable,
+            line.vertical,
+            line.language,
+            line.size,
+            formatNumberValue(line.creators, 0),
+            formatNumberValue(line.contentPieces, 0),
+            formatNumberValue(line.estimatedViews, 0),
+            formatNumberValue(line.cogsTotal, 2),
+            formatNumberValue(line.clientTotal, 2),
+            formatNumberValue(line.cogsCpv, 3),
+            formatNumberValue(line.clientCpv, 3),
+            formatNumberValue(line.clientCpm, 2),
+            rush,
+            travel,
+            niche,
+            marginGoalLabel,
+          ]);
+        });
+
+        if (otherTotal > 0) {
+          const otherClientTotal = otherTotal * priceMultiplier;
+          rows.push([
+            campaignName,
+            brand,
+            'Other Costs',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            formatNumberValue(otherTotal, 2),
+            formatNumberValue(otherClientTotal, 2),
+            '',
+            '',
+            '',
+            rush,
+            travel,
+            niche,
+            marginGoalLabel,
+          ]);
+        }
+
+        if (travelCost > 0) {
+          const travelClientTotal = travelCost * priceMultiplier;
+          rows.push([
+            campaignName,
+            brand,
+            'Travel',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            formatNumberValue(travelCost, 2),
+            formatNumberValue(travelClientTotal, 2),
+            '',
+            '',
+            '',
+            rush,
+            travel,
+            niche,
+            marginGoalLabel,
+          ]);
+        }
+
+        if (paidBudget > 0) {
+          const paidCpv = paidViews > 0 ? paidBudget / paidViews : 0;
+          const paidCpm = paidCpv * 1000;
+          rows.push([
+            campaignName,
+            brand,
+            'Paid Media',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            formatNumberValue(paidViews, 0),
+            formatNumberValue(paidBudget, 2),
+            formatNumberValue(paidBudget, 2),
+            formatNumberValue(paidCpv, 3),
+            formatNumberValue(paidCpv, 3),
+            formatNumberValue(paidCpm, 2),
+            rush,
+            travel,
+            niche,
+            marginGoalLabel,
+          ]);
+        }
+
+        const overallCogsCpv = summary.totalViews > 0 ? totalCOGs / summary.totalViews : 0;
+        const totalClientCpv = summary.totalViews > 0 ? totalPrice / summary.totalViews : 0;
+        const totalClientCpm = summary.brandCPM;
+
+        rows.push([
+          campaignName,
+          brand,
+          'TOTAL',
+          '',
+          '',
+          '',
+          '',
+          formatNumberValue(summary.totalCreators, 0),
+          formatNumberValue(summary.totalContentPieces, 0),
+          formatNumberValue(summary.totalViews, 0),
+          formatNumberValue(totalCOGs, 2),
+          formatNumberValue(totalPrice, 2),
+          formatNumberValue(overallCogsCpv, 3),
+          formatNumberValue(totalClientCpv, 3),
+          formatNumberValue(totalClientCpm, 2),
+          rush,
+          travel,
+          niche,
+          marginGoalLabel,
+        ]);
+
+        const headerLine = headers.map(wrapCsvValue).join(',');
+        const rowLines = rows.map(row => row.map(wrapCsvValue).join(',')).join('\n');
+        const csvContent = rows.length ? `${headerLine}\n${rowLines}` : headerLine;
+        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        const safeName = campaignName.replace(/[\\/:*?"<>|]+/g, '').replace(/\s+/g, '_');
+        anchor.download = `${safeName || 'campaign_export'}.csv`;
+        anchor.style.display = 'none';
+        document.body.appendChild(anchor);
+        anchor.click();
+        requestAnimationFrame(() => {
+          document.body.removeChild(anchor);
+          URL.revokeObjectURL(url);
+        });
+      } catch (error) {
+        console.error('Failed to export campaign as CSV', error);
+      }
     }
 
     // Pick only the deliverable fields that a template should remember.
@@ -2853,6 +3351,297 @@
       }
     }
 
+    function PricingVariablesMenu({ open, onClose }) {
+      const [showAdvanced, setShowAdvanced] = useState(false);
+
+      useEffect(() => {
+        if (!open) return undefined;
+        const handleKeyDown = event => {
+          if (event.key === 'Escape' && typeof onClose === 'function') {
+            onClose();
+          }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+      }, [open, onClose]);
+
+      useEffect(() => {
+        if (!open) {
+          setShowAdvanced(false);
+        }
+      }, [open]);
+
+      if (!open) return null;
+
+      const { general, paidMedia, multipliers, followers, deliverables } = pricingVariables;
+      const sizeOrder = Object.keys(multipliers.size || {});
+
+      const formatUplift = multiplier => {
+        if (!Number.isFinite(multiplier)) return '0%';
+        const delta = (multiplier - 1) * 100;
+        const rounded = Math.abs(delta) >= 1 ? delta.toFixed(0) : delta.toFixed(2);
+        const prefix = delta > 0 ? '+' : '';
+        return `${prefix}${rounded}%`;
+      };
+
+      const generalItems = [
+        ['Default margin goal', `${Number(general.marginGoal || 0).toFixed(0)}%`],
+        ['Rush fee uplift', formatUplift(general.rushFeeMultiplier)],
+        ['Travel uplift', formatUplift(general.travelFeeMultiplier)],
+        ['Niche creator uplift', formatUplift(general.nicheCreatorMultiplier)],
+        ['Q4 uplift', formatUplift(general.q4FeeMultiplier)],
+      ];
+
+      const commonSections = [
+        h('div', { className: 'pricing-menu-section', key: 'general' },
+          h('h4', null, 'General Pricing Inputs'),
+          h('p', { className: 'pricing-menu-description' },
+            'High-level assumptions that shape creator compensation and client pricing.',
+          ),
+          h('div', { className: 'pricing-variable-grid' },
+            generalItems.map(([label, value]) => h('div', { key: label, className: 'pricing-variable-item' },
+              h('span', { className: 'pricing-variable-label' }, label),
+              h('span', { className: 'pricing-variable-value' }, value),
+            )),
+          ),
+        ),
+        h('div', { className: 'pricing-menu-section', key: 'paid-media' },
+          h('h4', null, 'Paid Media Defaults'),
+          h('p', { className: 'pricing-menu-description' },
+            'Used when estimating paid amplification budgets and expected views.',
+          ),
+          h('div', { className: 'pricing-menu-table-wrapper' },
+            h('table', null,
+              h('thead', null,
+                h('tr', null,
+                  h('th', null, 'Mode'),
+                  h('th', null, 'Default Rate'),
+                  h('th', null, 'Unit'),
+                ),
+              ),
+              h('tbody', null,
+                Object.entries(paidMedia.defaultRates || {}).map(([mode, rate]) => {
+                  const isCpm = mode.toLowerCase() === 'cpm';
+                  return h('tr', { key: mode },
+                    h('td', null, mode.toUpperCase()),
+                    h('td', null, `$${Number(rate || 0).toFixed(2)}`),
+                    h('td', null, isCpm ? 'Per 1,000 views' : 'Per view'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+        h('div', { className: 'pricing-menu-section', key: 'sizes' },
+          h('h4', null, 'Creator Size Benchmarks'),
+          h('p', { className: 'pricing-menu-description' },
+            'Baseline view multipliers and follower expectations by creator size.',
+          ),
+          h('div', { className: 'pricing-menu-table-wrapper' },
+            h('table', null,
+              h('thead', null,
+                h('tr', null,
+                  h('th', null, 'Size'),
+                  h('th', null, 'View Multiplier'),
+                  h('th', null, 'Estimated Followers'),
+                ),
+              ),
+              h('tbody', null,
+                sizeOrder.map(size => {
+                  const config = multipliers.size[size] || {};
+                  const followerCount = followers[size];
+                  return h('tr', { key: size },
+                    h('td', null, size),
+                    h('td', null, `${Number(config.views ?? 1).toFixed(2)}x`),
+                    h('td', null, followerCount ? formatNumber(followerCount) : '—'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ];
+
+      const audienceSection = h('div', { className: 'pricing-menu-section', key: 'audience' },
+        h('h4', null, 'Audience Adjustments'),
+        h('p', { className: 'pricing-menu-description' },
+          'Rate and view modifiers applied for vertical or language-specific campaigns.',
+        ),
+        h('div', { className: 'pricing-variable-grid' },
+          h('div', { className: 'pricing-menu-table-wrapper', key: 'vertical' },
+            h('table', null,
+              h('thead', null,
+                h('tr', null,
+                  h('th', null, 'Vertical'),
+                  h('th', null, 'Rate Multiplier'),
+                  h('th', null, 'View Multiplier'),
+                ),
+              ),
+              h('tbody', null,
+                Object.entries(multipliers.vertical || {}).map(([vertical, values]) => h('tr', { key: vertical },
+                  h('td', null, vertical),
+                  h('td', null, `${Number(values.rate ?? 1).toFixed(2)}x`),
+                  h('td', null, `${Number(values.views ?? 1).toFixed(2)}x`),
+                )),
+              ),
+            ),
+          ),
+          h('div', { className: 'pricing-menu-table-wrapper', key: 'language' },
+            h('table', null,
+              h('thead', null,
+                h('tr', null,
+                  h('th', null, 'Language'),
+                  h('th', null, 'Rate Multiplier'),
+                  h('th', null, 'View Multiplier'),
+                ),
+              ),
+              h('tbody', null,
+                Object.entries(multipliers.language || {}).map(([language, values]) => h('tr', { key: language },
+                  h('td', null, language),
+                  h('td', null, `${Number(values.rate ?? 1).toFixed(2)}x`),
+                  h('td', null, `${Number(values.views ?? 1).toFixed(2)}x`),
+                )),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const feeSection = h('div', { className: 'pricing-menu-section', key: 'fees' },
+        h('h4', null, 'Special Fees & Sentiment'),
+        h('p', { className: 'pricing-menu-description' },
+          'Additional adjustments applied for whitelisting usage or brand sentiment.',
+        ),
+        h('div', { className: 'pricing-variable-grid' },
+          h('div', { className: 'pricing-menu-table-wrapper', key: 'whitelist' },
+            h('table', null,
+              h('thead', null,
+                h('tr', null,
+                  h('th', null, 'Creator Size'),
+                  h('th', null, 'Whitelist Uplift'),
+                ),
+              ),
+              h('tbody', null,
+                Object.entries(multipliers.whitelist || {}).map(([size, uplift]) => h('tr', { key: size },
+                  h('td', null, size),
+                  h('td', null, formatUplift(1 + (uplift || 0))),
+                )),
+              ),
+            ),
+          ),
+          h('div', { className: 'pricing-menu-table-wrapper', key: 'sentiment' },
+            h('table', null,
+              h('thead', null,
+                h('tr', null,
+                  h('th', null, 'Brand Sentiment'),
+                  h('th', null, 'Fee Impact'),
+                ),
+              ),
+              h('tbody', null,
+                (multipliers.brandExcitement || []).map((entry, index) => h('tr', { key: `${entry.label}-${index}` },
+                  h('td', null, entry.label || `Level ${index + 1}`),
+                  h('td', null, formatUplift(entry.multiplier ?? 1)),
+                )),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const deliverableCards = [];
+      Object.entries(deliverables || {}).forEach(([platform, items]) => {
+        Object.entries(items || {}).forEach(([deliverable, detail]) => {
+          const viewStrings = sizeOrder
+            .filter(size => Number.isFinite(detail.viewsBySize?.[size]))
+            .map(size => `${size}: ${formatNumber(detail.viewsBySize[size])}`);
+          const cpvStrings = Object.entries(detail.cpvByVertical || {})
+            .map(([vertical, cpvValue]) => `${vertical}: ${formatCpv(Number(cpvValue || 0))}`);
+          const baseViewLabel = detail.viewsBySize?.Macro ?? detail.baseViews ?? 0;
+          deliverableCards.push(h('div', { key: `${platform}-${deliverable}`, className: 'pricing-deliverable-card' },
+            h('h5', null, `${platform} — ${deliverable}`),
+            h('div', { className: 'pricing-deliverable-meta' },
+              h('span', null,
+                h('strong', null, 'Base CPV:'),
+                ` ${formatCpv(Number(detail.cpv || 0))}`,
+              ),
+              h('span', null,
+                h('strong', null, 'Macro views:'),
+                ` ${formatNumber(baseViewLabel || 0)}`,
+              ),
+            ),
+            viewStrings.length
+              ? h('div', { className: 'pricing-deliverable-meta' },
+                  h('span', null,
+                    h('strong', null, 'Views by size:'),
+                    ` ${viewStrings.join(' • ')}`,
+                  ),
+                )
+              : null,
+            cpvStrings.length
+              ? h('div', { className: 'pricing-deliverable-meta' },
+                  h('span', null,
+                    h('strong', null, 'CPV by vertical:'),
+                    ` ${cpvStrings.join(' • ')}`,
+                  ),
+                )
+              : null,
+          ));
+        });
+      });
+
+      const advancedSections = [
+        audienceSection,
+        feeSection,
+        h('div', { className: 'pricing-menu-section', key: 'deliverables' },
+          h('h4', null, 'Platform Deliverable Benchmarks'),
+          h('p', { className: 'pricing-menu-description' },
+            'Base views and CPVs that power the deliverable-level rate card.',
+          ),
+          h('div', { className: 'pricing-deliverable-grid' }, deliverableCards),
+        ),
+      ];
+
+      return h('div', {
+        className: 'pricing-menu-backdrop',
+        onClick: () => { if (typeof onClose === 'function') onClose(); },
+      },
+        h('div', {
+          className: 'pricing-menu',
+          role: 'dialog',
+          'aria-modal': 'true',
+          onClick: event => event.stopPropagation(),
+        },
+          h('div', { className: 'pricing-menu-header' },
+            h('div', null,
+              h('h3', null, 'Pricing Variables'),
+              h('p', { className: 'pricing-menu-description' },
+                'Reference-only view of the cost assumptions used across the Precise Influencer Calculator.',
+              ),
+            ),
+            h('button', {
+              className: 'pricing-menu-close',
+              onClick: () => { if (typeof onClose === 'function') onClose(); },
+            }, 'Close'),
+          ),
+          h('div', { className: 'pricing-menu-toggle' },
+            h('p', { className: 'pricing-menu-description' },
+              'Review baseline values or expand to inspect advanced adjustments.',
+            ),
+            h('label', null,
+              h('input', {
+                type: 'checkbox',
+                checked: showAdvanced,
+                onChange: event => setShowAdvanced(event.target.checked),
+              }),
+              'Show advanced variables',
+            ),
+          ),
+          ...commonSections,
+          ...(showAdvanced ? advancedSections : []),
+        ),
+      );
+    }
+
     function CampaignCard({ campaign, onEdit, onDuplicate, onDelete }) {
       const budgetDisplay = campaign.budget > 0 ? formatCurrency(campaign.budget) : 'Not set';
       const creatorLabel = formatNumber(campaign.totalCreators || 0);
@@ -2933,6 +3722,10 @@
         h('div', { className: 'campaign-card-actions' },
           h('button', { onClick: () => onEdit(campaign.id) }, 'Edit'),
           h('button', {
+            className: 'secondary',
+            onClick: () => exportCampaignToCSV(campaign),
+          }, 'Export CSV'),
+          h('button', {
             className: 'danger',
             onClick: () => {
               const label = campaign.name ? `"${campaign.name}"` : 'this campaign';
@@ -2956,29 +3749,36 @@
       selectedTemplateId,
       onTemplateChange,
     }) {
+      const [showPricingVariables, setShowPricingVariables] = useState(false);
+      const handleOpenPricing = useCallback(() => setShowPricingVariables(true), []);
+      const handleClosePricing = useCallback(() => setShowPricingVariables(false), []);
       const options = [
         h('option', { key: 'blank', value: '' }, 'Start from template (optional)'),
         ...templates.map(template => h('option', { key: template.id, value: template.id }, template.name)),
       ];
-      return h('div', { className: 'campaign-app' },
-        h('div', { className: 'campaign-toolbar' },
-          h('div', null,
-            h('h2', null, 'Campaigns'),
-            h('p', null, 'Manage saved campaigns, duplicate work, or start something new.'),
+      return h(React.Fragment, null,
+        h('div', { className: 'campaign-app' },
+          h('div', { className: 'campaign-toolbar' },
+            h('div', null,
+              h('h2', null, 'Campaigns'),
+              h('p', null, 'Manage saved campaigns, duplicate work, or start something new.'),
+            ),
+            h('div', { className: 'campaign-toolbar-actions' },
+              h('select', {
+                value: selectedTemplateId,
+                onChange: event => onTemplateChange(event.target.value),
+              }, options),
+              h('button', { className: 'secondary', onClick: handleOpenPricing }, 'Pricing Variables'),
+              h('button', { onClick: onCreate }, 'New Campaign'),
+            ),
           ),
-          h('div', { className: 'campaign-toolbar-actions' },
-            h('select', {
-              value: selectedTemplateId,
-              onChange: event => onTemplateChange(event.target.value),
-            }, options),
-            h('button', { onClick: onCreate }, 'New Campaign'),
-          ),
+          campaigns.length
+            ? h('div', { className: 'campaign-list' }, campaigns.map(campaign =>
+                h(CampaignCard, { key: campaign.id, campaign, onEdit, onDuplicate, onDelete }),
+              ))
+            : h('p', { className: 'campaign-dashboard-empty' }, 'No campaigns yet. Create a new campaign to get started.'),
         ),
-        campaigns.length
-          ? h('div', { className: 'campaign-list' }, campaigns.map(campaign =>
-              h(CampaignCard, { key: campaign.id, campaign, onEdit, onDuplicate, onDelete }),
-            ))
-          : h('p', { className: 'campaign-dashboard-empty' }, 'No campaigns yet. Create a new campaign to get started.'),
+        h(PricingVariablesMenu, { open: showPricingVariables, onClose: handleClosePricing }),
       );
     }
 
@@ -2992,6 +3792,11 @@
           ),
           h('div', { className: 'campaign-toolbar-actions' },
             h('button', { className: 'secondary', onClick: onBack }, 'Back to Campaigns'),
+            h('button', {
+              className: 'secondary',
+              onClick: () => { if (campaign) exportCampaignToCSV(campaign); },
+              disabled: !campaign,
+            }, 'Export CSV'),
             h('button', { onClick: onSaveTemplate }, 'Save as Template'),
           ),
         ),


### PR DESCRIPTION
## Summary
- add a reusable exportCampaignToCSV helper and surface CSV download buttons in the dashboard and editor toolbars
- define a pricingVariables reference object and present it through a toggleable Pricing Variables menu for quick assumption review
- style the new pricing variables overlay to match the existing dashboard aesthetics

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e274203eb88330b9a8357145503d59