### PR TITLE
Align Influencers.club tester and proxy to new API contract

### DIFF
--- a/client/src/api/apiKeyTests.ts
+++ b/client/src/api/apiKeyTests.ts
@@ -128,7 +128,7 @@ async function testInfluencersClubKey(keys: ApiKeys): Promise<ServiceTestResult>
 
   const payload = {
     platform: 'youtube',
-    paging: { limit: 1, page: 1 },
+    paging: { limit: 1, page: 0 },
     sort: { sort_by: 'relevancy', sort_order: 'desc' },
     filters: { ai_search: 'healthcheck', exclude_role_based_emails: false, exclude_previous: false }
   };
@@ -143,14 +143,14 @@ async function testInfluencersClubKey(keys: ApiKeys): Promise<ServiceTestResult>
     }
   }
 
-  const proxyUrl = `${getApiBase() || ''}/api/influencers-club/profile`;
+  const proxyUrl = `${getApiBase() || ''}/api/influencers-club/discovery`;
   try {
     return await runInfluencersValidation(proxyUrl, { ...payload, apiKey }, apiKey);
   } catch (proxyErr: any) {
     const proxyMessage = proxyErr?.message || 'Proxy validation failed.';
     return {
       ok: false,
-      message: `Influencers.club API: Failed to fetch. Proxy: ${proxyMessage}. If you are running from a static host, start the backend server and ensure /api/influencers-club/profile is reachable.`
+      message: `Influencers.club API: Failed to fetch. Proxy: ${proxyMessage}. If you are running from a static host, start the backend server and ensure /api/influencers-club/discovery is reachable.`
     };
   }
 }

--- a/client/src/components/InfluencersClubTester.tsx
+++ b/client/src/components/InfluencersClubTester.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { getApiBase } from '../api/backendConfig';
 
-type EndpointKey = 'discovery' | 'postData';
+type EndpointKey = 'discovery' | 'posts';
 
 type ResponseState = {
   status: number | null;
@@ -23,7 +23,7 @@ const ENDPOINTS: Record<
     legacyUrl: string;
     description: string;
     defaultPayload: Record<string, any>;
-    proxyPath: 'discovery' | 'content';
+    proxyPath: 'discovery' | 'posts';
     docSample?: Record<string, any>;
   }
 > = {
@@ -35,7 +35,7 @@ const ENDPOINTS: Record<
     proxyPath: 'discovery',
     defaultPayload: {
       platform: 'youtube',
-      paging: { limit: 5, page: 1 },
+      paging: { limit: 5, page: 0 },
       sort: { sort_by: 'relevancy', sort_order: 'desc' },
       filters: {
         location: [''],
@@ -46,7 +46,7 @@ const ENDPOINTS: Record<
     },
     docSample: {
       platform: 'youtube',
-      paging: { limit: 5, page: 1 },
+      paging: { limit: 5, page: 0 },
       sort: { sort_by: 'relevancy', sort_order: 'desc' },
       filters: {
         location: [''],
@@ -62,16 +62,17 @@ const ENDPOINTS: Record<
       }
     }
   },
-  postData: {
-    label: 'Post data (/public/v1/creators/content/details/)',
-    url: 'https://api-dashboard.influencers.club/public/v1/creators/content/details/',
-    legacyUrl: 'https://api.influencers.club/v1/creators/content/details/',
-    description: 'POST only. Provide platform, content_type, and post_id.',
-    proxyPath: 'content',
+  posts: {
+    label: 'Posts (/public/v1/creators/content/posts/)',
+    url: 'https://api-dashboard.influencers.club/public/v1/creators/content/posts/',
+    legacyUrl: 'https://api.influencers.club/v1/creators/content/posts/',
+    description: 'POST only. Provide platform, handle, count, and pagination_token.',
+    proxyPath: 'posts',
     defaultPayload: {
       platform: 'youtube',
-      content_type: 'comments',
-      post_id: 'UCwh2SF7McSUf1GVFVk0nP8w'
+      handle: 'MrBeast',
+      count: 12,
+      pagination_token: ''
     }
   }
 };
@@ -117,19 +118,29 @@ async function postJsonAndFormat(
     }
   })();
 
-  return {
+  const formatted = {
     status: res.status,
     ok: res.ok,
     body: formatBodyPreview(prettyBody),
     endpoint: url
   };
+
+  if (!res.ok) {
+    const error = new Error(`Request failed with ${res.status}`);
+    (error as any).status = res.status;
+    (error as any).response = formatted;
+    (error as any).body = formatted.body;
+    throw error;
+  }
+
+  return formatted;
 }
 
 export default function InfluencersClubTester({ apiKey, onApiKeyChange }: InfluencersClubTesterProps) {
   const [selectedEndpoint, setSelectedEndpoint] = useState<EndpointKey>('discovery');
   const [payloadTextByEndpoint, setPayloadTextByEndpoint] = useState<Record<EndpointKey, string>>(() => ({
     discovery: JSON.stringify(ENDPOINTS.discovery.defaultPayload, null, 2),
-    postData: JSON.stringify(ENDPOINTS.postData.defaultPayload, null, 2)
+    posts: JSON.stringify(ENDPOINTS.posts.defaultPayload, null, 2)
   }));
   const [isSending, setIsSending] = useState(false);
   const [response, setResponse] = useState<ResponseState | null>(null);
@@ -163,7 +174,7 @@ export default function InfluencersClubTester({ apiKey, onApiKeyChange }: Influe
 
     const trimmedKey = apiKey?.trim();
     if (!trimmedKey) {
-      setError('Add your Influencers.club API key above (case-sensitive “Bearer <token>” format).');
+      setError('Add your Influencers.club API key above (raw key only; Bearer is added automatically).');
       return;
     }
 
@@ -184,7 +195,7 @@ export default function InfluencersClubTester({ apiKey, onApiKeyChange }: Influe
     };
     const directTargets = [endpointMeta.url, endpointMeta.legacyUrl].filter(Boolean);
     const proxyTarget = buildProxyUrl(endpointMeta.proxyPath);
-    let lastDirectError: Error | null = null;
+    let lastDirectError: any = null;
 
     setIsSending(true);
     try {
@@ -212,6 +223,20 @@ export default function InfluencersClubTester({ apiKey, onApiKeyChange }: Influe
       );
       setResponse(proxied);
     } catch (err: any) {
+      const directResponseBody = lastDirectError?.response?.body || lastDirectError?.body;
+      const proxyResponseBody = err?.response?.body || err?.body;
+      if (proxyResponseBody || directResponseBody) {
+        setResponse(
+          err?.response ||
+            lastDirectError?.response || {
+              status: err?.status || lastDirectError?.status || null,
+              ok: false,
+              body: formatBodyPreview(proxyResponseBody || directResponseBody),
+              endpoint: err?.response?.endpoint || lastDirectError?.response?.endpoint || proxyTarget || endpointMeta.url
+            }
+        );
+      }
+
       const proxyMessage = err?.message || 'Proxy request failed.';
       const directMessage =
         lastDirectError?.message || (!proxyTarget ? proxyMessage : 'Failed to reach Influencers.club.');
@@ -256,7 +281,7 @@ export default function InfluencersClubTester({ apiKey, onApiKeyChange }: Influe
             onChange={(e) => onApiKeyChange(e.target.value)}
           />
           <span className="text-muted" style={{ display: 'block', marginTop: 4 }}>
-            Pasted verbatim into <code>Authorization: Bearer &lt;your-key&gt;</code>; no prefixes are added or removed.
+            Paste the raw key only; the tester automatically sends <code>Authorization: Bearer &lt;your-key&gt;</code>.
           </span>
         </label>
 

--- a/server/src/influencersClub/influencersClubRoutes.ts
+++ b/server/src/influencersClub/influencersClubRoutes.ts
@@ -140,7 +140,7 @@ router.post('/email', async (req, res) => {
 
   const payload = {
     platform,
-    paging: { limit: 1, page: 1 },
+    paging: { limit: 1, page: 0 },
     sort: { sort_by: 'relevancy', sort_order: 'desc' },
     filters: {
       channel_url: [channelUrl],


### PR DESCRIPTION
### Motivation
- Parts of the codebase were using the newer Influencers.club posts contract while other areas (tester, API key tests, server email lookup) still relied on the older contract, causing direct requests and proxy fallbacks to behave inconsistently.
- The goal is to minimally update the tester, validation, and server proxy behavior so the client can call the current API shapes and fall back to the backend proxy when appropriate.

### Description
- Updated `client/src/components/InfluencersClubTester.tsx` to use endpoint keys `discovery` and `posts`, updated discovery paging to `page: 0`, switched the post endpoint to `/public/v1/creators/content/posts/` with default payload `{ platform: 'youtube', handle: 'MrBeast', count: 12, pagination_token: '' }`, and changed the proxy path to `posts`.
- Reworked tester request logic so non-2xx direct responses now throw structured errors including `status` and a formatted response body, enabling fallback to the proxy on network errors and on 404/405, and preserved the response body in the UI when showing combined direct/proxy error messaging.
- Updated the API key validation in `client/src/api/apiKeyTests.ts` to use `paging: { limit: 1, page: 0 }` and to validate the proxy using `/api/influencers-club/discovery` instead of the stale `/profile` proxy route.
- Updated the server email lookup in `server/src/influencersClub/influencersClubRoutes.ts` to use `paging: { limit: 1, page: 0 }` and confirmed proxy routes are wired for `/discovery` and `/posts` while keeping `/content` and `/profile` as backward-compatibility aliases.

### Testing
- Built the client with `npm --prefix client run build`, which completed successfully.
- Built the server with `npm --prefix server run build`, which completed successfully.
- Verified the running frontend and captured a screenshot via Playwright to exercise the updated tester UI, which completed successfully and produced an artifact.
- Searched the repository for remaining stale patterns (`creators/content/details`, `proxyPath: 'content'`, `/api/influencers-club/profile`, `page: 1`, and `Bearer <token>` guidance) and confirmed there are no active client/server paths left using the stale paging/route or misleading API key copy; the server still retains `CONTENT_DETAILS_PATH` and compatibility routes intentionally.
- All automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73e0061cc83309d2cc1bb0d492cfd)