### PR TITLE
Set default paid media CPV to 0.06

### DIFF
--- a/client/public/legacy-calculator.html
+++ b/client/public/legacy-calculator.html
@@ -1547,7 +1547,7 @@
     const CPV_WITH_MARGIN_LABEL = 'Client CPV (Including Margin)';
 
     const DEFAULT_PAID_RATES = {
-      cpv: 0.03,
+      cpv: 0.06,
       cpm: 12,
     };
 

--- a/docs/legacy-calculator.html
+++ b/docs/legacy-calculator.html
@@ -1547,7 +1547,7 @@
     const CPV_WITH_MARGIN_LABEL = 'Client CPV (Including Margin)';
 
     const DEFAULT_PAID_RATES = {
-      cpv: 0.03,
+      cpv: 0.06,
       cpm: 12,
     };
 

--- a/index.html
+++ b/index.html
@@ -1547,7 +1547,7 @@
     const CPV_WITH_MARGIN_LABEL = 'Client CPV (Including Margin)';
 
     const DEFAULT_PAID_RATES = {
-      cpv: 0.03,
+      cpv: 0.06,
       cpm: 12,
     };
 


### PR DESCRIPTION
### Motivation
- Align the default Client CPV used for paid media to `0.06` and keep all mirrored calculator entrypoints consistent.

### Description
- Update `DEFAULT_PAID_RATES.cpv` from `0.03` to `0.06` in `client/public/legacy-calculator.html`, `docs/legacy-calculator.html`, and `index.html`.

### Testing
- Performed a scripted replace and verified the change with `rg -n "DEFAULT_PAID_RATES =|cpv: 0.06" client/public/legacy-calculator.html docs/legacy-calculator.html index.html` and inspected the changes with `git diff -- client/public/legacy-calculator.html docs/legacy-calculator.html index.html`, both showing the updated value only and no other regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb3212c0c8330b1348641ac936985)