### PR TITLE
Fix line COGS paid media toggle updates

### DIFF
--- a/client/public/legacy-calculator.html
+++ b/client/public/legacy-calculator.html
@@ -3462,8 +3462,9 @@
       const sizeContentPieces = {};
       contentLines.forEach(line => {
         const lineTotal = line.total || 0;
+        const adjusted = lineTotal * modifiers.feeMultiplier;
+        line.cogsTotal = Number.isFinite(adjusted) ? adjusted : lineTotal;
         if (lineTotal > 0) {
-          const adjusted = lineTotal * modifiers.feeMultiplier;
           const languageKey = line.language || 'Unspecified';
           const verticalKey = line.vertical || 'Unspecified';
           platformBudget[line.platform] = (platformBudget[line.platform] || 0) + adjusted;
@@ -4201,7 +4202,8 @@
         }
         const totalCell = row.children?.[11];
         if (totalCell) {
-          totalCell.textContent = formatCurrency(line.total);
+          const totalCogs = Number.isFinite(line.cogsTotal) ? line.cogsTotal : line.total;
+          totalCell.textContent = formatCurrency(totalCogs || 0);
         }
       });
     }

--- a/docs/legacy-calculator.html
+++ b/docs/legacy-calculator.html
@@ -3462,8 +3462,9 @@
       const sizeContentPieces = {};
       contentLines.forEach(line => {
         const lineTotal = line.total || 0;
+        const adjusted = lineTotal * modifiers.feeMultiplier;
+        line.cogsTotal = Number.isFinite(adjusted) ? adjusted : lineTotal;
         if (lineTotal > 0) {
-          const adjusted = lineTotal * modifiers.feeMultiplier;
           const languageKey = line.language || 'Unspecified';
           const verticalKey = line.vertical || 'Unspecified';
           platformBudget[line.platform] = (platformBudget[line.platform] || 0) + adjusted;
@@ -4201,7 +4202,8 @@
         }
         const totalCell = row.children?.[11];
         if (totalCell) {
-          totalCell.textContent = formatCurrency(line.total);
+          const totalCogs = Number.isFinite(line.cogsTotal) ? line.cogsTotal : line.total;
+          totalCell.textContent = formatCurrency(totalCogs || 0);
         }
       });
     }

--- a/index.html
+++ b/index.html
@@ -3462,8 +3462,9 @@
       const sizeContentPieces = {};
       contentLines.forEach(line => {
         const lineTotal = line.total || 0;
+        const adjusted = lineTotal * modifiers.feeMultiplier;
+        line.cogsTotal = Number.isFinite(adjusted) ? adjusted : lineTotal;
         if (lineTotal > 0) {
-          const adjusted = lineTotal * modifiers.feeMultiplier;
           const languageKey = line.language || 'Unspecified';
           const verticalKey = line.vertical || 'Unspecified';
           platformBudget[line.platform] = (platformBudget[line.platform] || 0) + adjusted;
@@ -4201,7 +4202,8 @@
         }
         const totalCell = row.children?.[11];
         if (totalCell) {
-          totalCell.textContent = formatCurrency(line.total);
+          const totalCogs = Number.isFinite(line.cogsTotal) ? line.cogsTotal : line.total;
+          totalCell.textContent = formatCurrency(totalCogs || 0);
         }
       });
     }


### PR DESCRIPTION
### Motivation
- The paid-media duration checkboxes (1m/3m/6m) updated the global fee multiplier but line-level Total COGS shown in the table continued to display the unadjusted base totals, so toggling paid media didn't appear to affect per-creator totals.

### Description
- Calculate the fee-adjusted line COGS inside `recalc()` by computing `adjusted = line.total * modifiers.feeMultiplier` and store it on the line as `line.cogsTotal` so downstream views can use the adjusted value.
- Use `line.cogsTotal` (with a safe fallback to `line.total`) when rendering the table "Total COGs" cell so the UI shows the fee-adjusted per-line totals.
- Apply the same fixes to the root static copy and the docs copy of the legacy calculator (`client/public/legacy-calculator.html`, `index.html`, `docs/legacy-calculator.html`).
- Rebuilt the client output so the docs/production copy includes the fix.

### Testing
- Ran the production build with `npm --prefix client run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f32a89e8833080919ac14da0a2cc)